### PR TITLE
Make lib.y.xplugin a maven transtive dependency of lib.y (closer to 1 jar with 2 modules) 

### DIFF
--- a/app-x-and-y/pom.xml
+++ b/app-x-and-y/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>example-parent</artifactId>
-    <version>1</version>
+    <version>2</version>
   </parent>
 
   <artifactId>app-xy</artifactId>
@@ -15,21 +15,21 @@
     <dependency>
       <groupId>org.example</groupId>
       <artifactId>lib-x</artifactId>
-      <version>1</version>
+      <version>2</version>
     </dependency>
 
     <dependency>
       <groupId>org.example</groupId>
       <artifactId>lib-y</artifactId>
-      <version>1</version>
+      <version>2</version>
     </dependency>
 
-    <!-- Ideally users don't have to explicitly include this dependency -->
-    <dependency>
-      <groupId>org.example</groupId>
-      <artifactId>lib-y-xplugin</artifactId>
-      <version>1</version>
-    </dependency>
+<!--    &lt;!&ndash; Ideally users don't have to explicitly include this dependency &ndash;&gt;-->
+<!--    <dependency>-->
+<!--      <groupId>org.example</groupId>-->
+<!--      <artifactId>lib-y-xplugin</artifactId>-->
+<!--      <version>2</version>-->
+<!--    </dependency>-->
 
   </dependencies>
 

--- a/app-y-only/pom.xml
+++ b/app-y-only/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>example-parent</artifactId>
-    <version>1</version>
+    <version>2</version>
   </parent>
 
   <artifactId>app-y-only</artifactId>
@@ -15,13 +15,13 @@
     <dependency>
       <groupId>org.example</groupId>
       <artifactId>lib-y</artifactId>
-      <version>1</version>
+      <version>2</version>
     </dependency>
 
 <!--    <dependency>-->
 <!--      <groupId>org.example</groupId>-->
 <!--      <artifactId>lib-y-xplugin</artifactId>-->
-<!--      <version>1</version>-->
+<!--      <version>2</version>-->
 <!--    </dependency>-->
 
   </dependencies>

--- a/lib-x/pom.xml
+++ b/lib-x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.example</groupId>
         <artifactId>example-parent</artifactId>
-        <version>1</version>
+        <version>2</version>
     </parent>
 
     <artifactId>lib-x</artifactId>

--- a/lib-y-xplugin/pom.xml
+++ b/lib-y-xplugin/pom.xml
@@ -6,23 +6,23 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>example-parent</artifactId>
-    <version>1</version>
+    <version>2</version>
   </parent>
 
   <artifactId>lib-y-xplugin</artifactId>
-<!--  <version>1</version>-->
+<!--  <version>2</version>-->
 
   <dependencies>
     <dependency>
       <groupId>org.example</groupId>
       <artifactId>lib-y</artifactId>
-      <version>1</version>
+      <version>2</version>
     </dependency>
 
     <dependency>
       <groupId>org.example</groupId>
       <artifactId>lib-x</artifactId>
-      <version>1</version>
+      <version>2</version>
       <scope>provided</scope>
     </dependency>
 

--- a/lib-y/pom.xml
+++ b/lib-y/pom.xml
@@ -6,20 +6,20 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>example-parent</artifactId>
-    <version>1</version>
+    <version>2</version>
   </parent>
 
   <artifactId>lib-y</artifactId>
   <dependencies>
 
     <!-- Workaround for maven cyclical dependency -->
-    <!-- Always just bring in the plugin dependency -->
-    <!-- and closely match 1 jar with 2 modules -->
-<!--        <dependency>-->
-<!--          <groupId>org.example</groupId>-->
-<!--          <artifactId>lib-y-xplugin</artifactId>-->
-<!--          <version>1</version>-->
-<!--        </dependency>-->
+    <!-- to depend on (version-1) of lib-y-xplugin -->
+    <!-- to closely match 1 jar with 2 modules -->
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>lib-y-xplugin</artifactId>
+      <version>1</version>
+    </dependency>
 
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.example</groupId>
   <artifactId>example-parent</artifactId>
-  <version>1</version>
+  <version>2</version>
   <packaging>pom</packaging>
 
   <scm>


### PR DESCRIPTION
This more closely simulates the 2 modules in 1 jar scenario. Modifies lib.y to add a maven dependency on lib.y.xplugin (using version-1 to break maven only cyclical dependency).
This requires a prior mvn install for version 1.

- apps depending on lib-y "just works" by default (both with/without lib-x in the path)
- lib-y by default brings in lib-y-xplugin as a maven transitive dependency 
- lib-y-xplugin is a detail that users don't need to know about by default
- works well given a stable implementation in lib-y-xplugin
- looks a bit 'dirty/ugly' as it introduces a maven cyclical dependency which we work around using `version - 1` (but only maintainers of lib-y need to deal with this and it's a _maven only cyclical dependency_ and not a module-info one)


## app-xy maven dependency tree
```
[INFO] org.example:app-xy:jar:2
[INFO] +- org.example:lib-x:jar:2:compile
[INFO] +- org.example:lib-y:jar:2:compile
[INFO] |  \- org.example:lib-y-xplugin:jar:1:compile
```
- lib-x successfully loads the plugin from lib-y-xplugin


## app y only maven dependency tree
```
[INFO] org.example:app-y-only:jar:2
[INFO] +- org.example:lib-y:jar:2:compile
[INFO] |  \- org.example:lib-y-xplugin:jar:1:compile
```
- lib-y-xplugin is effectively dead code / not used. 
- Does NOT break module resolution at runtime.